### PR TITLE
fix: tolerate Atlas clusters without private endpoints +semver: fix

### DIFF
--- a/locals-atlas.tf
+++ b/locals-atlas.tf
@@ -20,13 +20,14 @@ locals {
     clusteradmin = "ca"
   }
   pvt_endpoints = merge([for k, v in data.mongodbatlas_advanced_cluster.cluster : {
-    for ep in try(v.connection_strings.private_endpoint, []) : "${k}-${ep.endpoints[0].endpoint_id}" => {
+    for ep in coalesce(try(v.connection_strings.private_endpoint, null), []) : "${k}-${ep.endpoints[0].endpoint_id}" => {
       connection     = try(ep.connection_string, "")
       srv_connection = try(ep.srv_connection_string, "")
       pvt            = split("/", try(ep.connection_string, ""))
       pvt_srv        = split("/", try(ep.srv_connection_string, ""))
       endpoint_id    = ep.endpoints[0].endpoint_id
     }
+    if try(ep.endpoints[0].endpoint_id, "") != ""
     }
   ]...)
   connection_strings_arrs = {


### PR DESCRIPTION
## Summary

- Normalize `connection_strings.private_endpoint` to an empty list when Atlas returns it as null or omits it.
- Skip malformed private endpoint entries without an endpoint id while preserving public connection string generation.

## Verification

- `tofu fmt -recursive`
- `tofu fmt -check -recursive`
- `git diff --check`
- `tofu init -backend=false -input=false`
- `tofu validate -no-color`
- `tofu console` confirmed `try(null, [])` returns null and `coalesce(try(null, null), [])` returns `[]`.

+semver: fix